### PR TITLE
Remove use of anyhow and replace with thiserror, other markups

### DIFF
--- a/azure-kusto-ingest/Cargo.toml
+++ b/azure-kusto-ingest/Cargo.toml
@@ -13,11 +13,11 @@ azure_storage = "0.17"
 azure_storage_blobs = "0.17"
 azure_storage_queues = "0.17"
 
-anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 rand = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
+thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 url = "2"

--- a/azure-kusto-ingest/examples/ingest_from_blob.rs
+++ b/azure-kusto-ingest/examples/ingest_from_blob.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-use anyhow::Result;
 use azure_kusto_data::prelude::{ConnectionString, KustoClient, KustoClientOptions};
 use azure_kusto_ingest::data_format::DataFormat;
 use azure_kusto_ingest::descriptors::{BlobAuth, BlobDescriptor};
@@ -16,7 +15,7 @@ use azure_kusto_ingest::queued_ingest::QueuedIngestClient;
 /// - Permissions for Kusto to access storage
 ///     https://learn.microsoft.com/en-us/azure/data-explorer/ingest-data-managed-identity
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cluster_ingest_uri = env::var("KUSTO_INGEST_URI").expect("Must define KUSTO_INGEST_URI");
     let user_mi_object_id =
         env::var("KUSTO_USER_MI_OBJECT_ID").expect("Must define KUSTO_USER_MI_OBJECT_ID");
@@ -54,7 +53,9 @@ async fn main() -> Result<()> {
     let blob_descriptor = BlobDescriptor::new(blob_uri, blob_size, None)
         .with_blob_auth(BlobAuth::SystemAssignedManagedIdentity);
 
-    queued_ingest_client
+    let _ = queued_ingest_client
         .ingest_from_blob(blob_descriptor, ingestion_properties)
-        .await
+        .await?;
+
+    Ok(())
 }

--- a/azure-kusto-ingest/src/error.rs
+++ b/azure-kusto-ingest/src/error.rs
@@ -1,5 +1,4 @@
 //! Defines [Error] for representing failures in various operations.
-use std::fmt::Debug;
 
 use thiserror;
 

--- a/azure-kusto-ingest/src/error.rs
+++ b/azure-kusto-ingest/src/error.rs
@@ -1,0 +1,23 @@
+//! Defines [Error] for representing failures in various operations.
+use std::fmt::Debug;
+
+use thiserror;
+
+/// Error type for kusto ingestion operations.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Error raised when failing to obtain ingestion resources.
+    #[error("Error obtaining ingestion resources: {0}")]
+    ResourceManagerError(#[from] super::resource_manager::ResourceManagerError),
+
+    /// Error relating to (de-)serialization of JSON data
+    #[error("Error in JSON serialization/deserialization: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    /// Error occurring within core azure crates
+    #[error("Error in azure-core: {0}")]
+    AzureError(#[from] azure_core::error::Error),
+}
+
+/// Result type for kusto ingest operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/azure-kusto-ingest/src/error.rs
+++ b/azure-kusto-ingest/src/error.rs
@@ -1,7 +1,5 @@
 //! Defines [Error] for representing failures in various operations.
 
-use thiserror;
-
 /// Error type for kusto ingestion operations.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/azure-kusto-ingest/src/lib.rs
+++ b/azure-kusto-ingest/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod client_options;
 pub mod data_format;
 pub mod descriptors;
+pub mod error;
 pub(crate) mod ingestion_blob_info;
 pub mod ingestion_properties;
 pub mod queued_ingest;

--- a/azure-kusto-ingest/src/resource_manager.rs
+++ b/azure-kusto-ingest/src/resource_manager.rs
@@ -6,10 +6,10 @@ pub mod ingest_client_resources;
 pub mod resource_uri;
 pub mod utils;
 
-use anyhow::Result;
 use azure_kusto_data::prelude::KustoClient;
 
 use azure_storage_queues::QueueClient;
+use thiserror::Error;
 
 use crate::client_options::QueuedIngestClientOptions;
 
@@ -18,7 +18,25 @@ use self::{
     ingest_client_resources::IngestClientResources,
 };
 
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
 pub const RESOURCE_REFRESH_PERIOD: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Error)]
+pub enum ResourceManagerError {
+    #[error("Failed to obtain ingestion resources: {0}")]
+    IngestClientResourcesError(#[from] ingest_client_resources::IngestionResourceError),
+
+    #[error("Failed to obtain authorization token: {0}")]
+    AuthorizationContextError(#[from] authorization_context::KustoIdentityTokenError),
+
+    #[error("Failed to select a resource - no resources found")]
+    NoResourcesFound,
+}
+
+type Result<T> = std::result::Result<T, ResourceManagerError>;
 
 /// ResourceManager is a struct that keeps track of all the resources required for ingestion using the queued flavour
 pub struct ResourceManager {
@@ -39,12 +57,62 @@ impl ResourceManager {
     }
 
     /// Returns the latest [QueueClient]s ready for posting ingestion messages to
-    pub async fn ingestion_queues(&self) -> Result<Vec<QueueClient>> {
+    async fn ingestion_queues(&self) -> Result<Vec<QueueClient>> {
         Ok(self.ingest_client_resources.get().await?.ingestion_queues)
+    }
+
+    /// Returns a [QueueClient] to ingest to.
+    /// This is a random selection from the list of ingestion queues
+    pub async fn ingestion_queue(&self) -> Result<QueueClient> {
+        let ingestion_queues = self.ingestion_queues().await?;
+        let selected_queue = select_random_resource(ingestion_queues)?;
+        Ok(selected_queue.clone())
     }
 
     /// Returns the latest [KustoIdentityToken] to be added as an authorization context to ingestion messages
     pub async fn authorization_context(&self) -> Result<KustoIdentityToken> {
-        self.authorization_context.get().await
+        self.authorization_context
+            .get()
+            .await
+            .map_err(ResourceManagerError::AuthorizationContextError)
+    }
+}
+/// Selects a random resource from the given list of resources
+fn select_random_resource<T: Clone>(resources: Vec<T>) -> Result<T> {
+    let mut rng: StdRng = SeedableRng::from_entropy();
+    resources
+        .choose(&mut rng)
+        .ok_or(ResourceManagerError::NoResourcesFound)
+        .cloned()
+}
+
+#[cfg(test)]
+mod select_random_resource_tests {
+    use super::*;
+
+    #[test]
+    fn single_resource() {
+        const VALUE: i32 = 1;
+        let resources = vec![VALUE];
+        let selected_resource = select_random_resource(resources).unwrap();
+        assert!(selected_resource == VALUE)
+    }
+
+    #[test]
+    fn multiple_resources() {
+        let resources = vec![1, 2, 3, 4, 5];
+        let selected_resource = select_random_resource(resources.clone()).unwrap();
+        assert!(resources.contains(&selected_resource));
+    }
+
+    #[test]
+    fn no_resources() {
+        let resources: Vec<i32> = vec![];
+        let selected_resource = select_random_resource(resources);
+        assert!(selected_resource.is_err());
+        assert!(matches!(
+            selected_resource.unwrap_err(),
+            ResourceManagerError::NoResourcesFound
+        ))
     }
 }

--- a/azure-kusto-ingest/src/resource_manager.rs
+++ b/azure-kusto-ingest/src/resource_manager.rs
@@ -18,9 +18,7 @@ use self::{
     ingest_client_resources::IngestClientResources,
 };
 
-use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
-use rand::SeedableRng;
+use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 pub const RESOURCE_REFRESH_PERIOD: Duration = Duration::from_secs(60 * 60);
 

--- a/azure-kusto-ingest/src/resource_manager.rs
+++ b/azure-kusto-ingest/src/resource_manager.rs
@@ -9,7 +9,6 @@ pub mod utils;
 use azure_kusto_data::prelude::KustoClient;
 
 use azure_storage_queues::QueueClient;
-use thiserror::Error;
 
 use crate::client_options::QueuedIngestClientOptions;
 
@@ -22,7 +21,7 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 
 pub const RESOURCE_REFRESH_PERIOD: Duration = Duration::from_secs(60 * 60);
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ResourceManagerError {
     #[error("Failed to obtain ingestion resources: {0}")]
     IngestClientResourcesError(#[from] ingest_client_resources::IngestionResourceError),

--- a/azure-kusto-ingest/src/resource_manager/authorization_context.rs
+++ b/azure-kusto-ingest/src/resource_manager/authorization_context.rs
@@ -1,15 +1,40 @@
 use std::sync::Arc;
 
-use anyhow::Result;
 use azure_kusto_data::prelude::KustoClient;
+use serde_json::Value;
 use tokio::sync::RwLock;
 
 use super::cache::{Cached, ThreadSafeCachedValue};
 use super::utils::get_column_index;
 use super::RESOURCE_REFRESH_PERIOD;
+use thiserror::Error;
 
 pub(crate) type KustoIdentityToken = String;
 
+const AUTHORIZATION_CONTEXT: &str = "AuthorizationContext";
+
+#[derive(Error, Debug)]
+pub enum KustoIdentityTokenError {
+    #[error("Kusto expected 1 table in results, found {0}")]
+    ExpectedOneTable(usize),
+
+    #[error("Kusto expected 1 row in table, found {0}")]
+    ExpectedOneRow(usize),
+
+    #[error("Column {0} not found in table")]
+    ColumnNotFound(String),
+
+    #[error("Invalid JSON response from Kusto: {0:?}")]
+    InvalidJSONResponse(Value),
+
+    #[error("Token is empty")]
+    EmptyToken,
+
+    #[error(transparent)]
+    KustoError(#[from] azure_kusto_data::error::Error),
+}
+
+type Result<T> = std::result::Result<T, KustoIdentityTokenError>;
 /// Logic to obtain a Kusto identity token from the management endpoint. This auth token is a temporary token
 #[derive(Debug, Clone)]
 pub(crate) struct AuthorizationContext {
@@ -28,7 +53,9 @@ impl AuthorizationContext {
     }
 
     /// Executes a KQL query to get the Kusto identity token from the management endpoint
-    async fn query_kusto_identity_token(&self) -> Result<KustoIdentityToken> {
+    async fn query_kusto_identity_token(
+        &self,
+    ) -> Result<KustoIdentityToken> {
         let results = self
             .client
             .execute_command("NetDefaultDB", ".get kusto identity token", None)
@@ -38,38 +65,36 @@ impl AuthorizationContext {
         let table = match &results.tables[..] {
             [a] => a,
             _ => {
-                return Err(anyhow::anyhow!(
-                    "Kusto Expected 1 table in results, found {}",
-                    results.tables.len()
+                return Err(KustoIdentityTokenError::ExpectedOneTable(
+                    results.tables.len(),
                 ))
             }
         };
 
         // Check that a column in this table actually exists called `AuthorizationContext`
-        let index = get_column_index(table, "AuthorizationContext")?;
+        let index = get_column_index(table, AUTHORIZATION_CONTEXT).ok_or(
+            KustoIdentityTokenError::ColumnNotFound(AUTHORIZATION_CONTEXT.into()),
+        )?;
 
         // Check that there is only 1 row in the table, and that the value in the first row at the given index is not empty
         let token = match &table.rows[..] {
-            [row] => row.get(index).ok_or(anyhow::anyhow!(
-                "Kusto response did not contain a value in the first row at position {}",
-                index
-            ))?,
-            _ => {
-                return Err(anyhow::anyhow!(
-                    "Kusto expected 1 row in results, found {}",
-                    table.rows.len()
-                ))
-            }
+            [row] => row
+                .get(index)
+                .ok_or(KustoIdentityTokenError::ColumnNotFound(
+                    AUTHORIZATION_CONTEXT.into(),
+                ))?,
+            _ => return Err(KustoIdentityTokenError::ExpectedOneRow(table.rows.len())),
         };
 
         // Convert the JSON string into a Rust string
-        let token = token.as_str().ok_or(anyhow::anyhow!(
-            "Kusto response did not contain a string value: {:?}",
-            token
-        ))?;
+        let token = token
+            .as_str()
+            .ok_or(KustoIdentityTokenError::InvalidJSONResponse(
+                token.to_owned(),
+            ))?;
 
         if token.chars().all(char::is_whitespace) {
-            return Err(anyhow::anyhow!("Kusto identity token is empty"));
+            return Err(KustoIdentityTokenError::EmptyToken);
         }
 
         Ok(token.to_string())

--- a/azure-kusto-ingest/src/resource_manager/authorization_context.rs
+++ b/azure-kusto-ingest/src/resource_manager/authorization_context.rs
@@ -7,13 +7,12 @@ use tokio::sync::RwLock;
 use super::cache::{Cached, ThreadSafeCachedValue};
 use super::utils::get_column_index;
 use super::RESOURCE_REFRESH_PERIOD;
-use thiserror::Error;
 
 pub(crate) type KustoIdentityToken = String;
 
 const AUTHORIZATION_CONTEXT: &str = "AuthorizationContext";
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum KustoIdentityTokenError {
     #[error("Kusto expected 1 table in results, found {0}")]
     ExpectedOneTable(usize),

--- a/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
+++ b/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
@@ -5,18 +5,50 @@ use crate::client_options::QueuedIngestClientOptions;
 use super::{
     cache::{Cached, ThreadSafeCachedValue},
     resource_uri::{ClientFromResourceUri, ResourceUri},
-    utils::get_column_index,
-    RESOURCE_REFRESH_PERIOD,
+    utils, RESOURCE_REFRESH_PERIOD,
 };
-use anyhow::Result;
 use azure_core::ClientOptions;
 use azure_kusto_data::{models::TableV1, prelude::KustoClient};
 use azure_storage_blobs::prelude::ContainerClient;
 use azure_storage_queues::QueueClient;
+use serde_json::Value;
+use thiserror::Error;
 use tokio::sync::RwLock;
 
+#[derive(Debug, Error)]
+pub enum IngestionResourceError {
+    #[error("{column_name} column is missing in the table")]
+    ColumnNotFoundError { column_name: String },
+
+    #[error("Response returned from Kusto could not be parsed as a string: {0}")]
+    ParseAsStringError(Value),
+
+    #[error("No {0} resources found in the table")]
+    NoResourcesFound(String),
+
+    #[error(transparent)]
+    KustoError(#[from] azure_kusto_data::error::Error),
+
+    #[error(transparent)]
+    ResourceUriError(#[from] super::resource_uri::ResourceUriError),
+
+    #[error("Kusto expected a table containing ingestion resource results, found no tables")]
+    NoTablesFound,
+}
+
+type Result<T> = std::result::Result<T, IngestionResourceError>;
+
+fn get_column_index(table: &TableV1, column_name: &str) -> Result<usize> {
+    utils::get_column_index(table, column_name).ok_or(IngestionResourceError::ColumnNotFoundError {
+        column_name: column_name.to_string(),
+    })
+}
+
 /// Helper to get a resource URI from a table, erroring if there are no resources of the given name
-fn get_resource_by_name(table: &TableV1, resource_name: String) -> Result<Vec<ResourceUri>> {
+fn get_resource_by_name(
+    table: &TableV1,
+    resource_name: String,
+) -> Result<Vec<ResourceUri>> {
     let storage_root_index = get_column_index(table, "StorageRoot")?;
     let resource_type_name_index = get_column_index(table, "ResourceTypeName")?;
 
@@ -25,18 +57,15 @@ fn get_resource_by_name(table: &TableV1, resource_name: String) -> Result<Vec<Re
         .iter()
         .filter(|r| r[resource_type_name_index] == resource_name)
         .map(|r| {
-            ResourceUri::try_from(r[storage_root_index].as_str().ok_or(anyhow::anyhow!(
-                "Response returned from Kusto could not be parsed as a string {:?}",
-                r[storage_root_index]
-            ))?)
+            let x = r[storage_root_index].as_str().ok_or(
+                IngestionResourceError::ParseAsStringError(r[storage_root_index].clone()),
+            )?;
+            ResourceUri::try_from(x).map_err(IngestionResourceError::ResourceUriError)
         })
         .collect();
 
     if resource_uris.is_empty() {
-        return Err(anyhow::anyhow!(
-            "No {} resources found in the table",
-            resource_name
-        ));
+        return Err(IngestionResourceError::NoResourcesFound(resource_name));
     }
 
     resource_uris.into_iter().collect()
@@ -61,10 +90,12 @@ pub struct InnerIngestClientResources {
 }
 
 impl TryFrom<(&TableV1, &QueuedIngestClientOptions)> for InnerIngestClientResources {
-    type Error = anyhow::Error;
+    type Error = IngestionResourceError;
 
     /// Attempts to create a new InnerIngestClientResources from the given [TableV1] and [QueuedIngestClientOptions]
-    fn try_from((table, client_options): (&TableV1, &QueuedIngestClientOptions)) -> Result<Self> {
+    fn try_from(
+        (table, client_options): (&TableV1, &QueuedIngestClientOptions),
+    ) -> std::result::Result<Self, Self::Error> {
         let secured_ready_for_aggregation_queues =
             get_resource_by_name(table, "SecuredReadyForAggregationQueue".to_string())?;
         let temp_storage = get_resource_by_name(table, "TempStorage".to_string())?;
@@ -98,15 +129,18 @@ impl IngestClientResources {
     }
 
     /// Executes a KQL management query that retrieves resource URIs for the various Azure resources used for ingestion
-    async fn query_ingestion_resources(&self) -> Result<InnerIngestClientResources> {
+    async fn query_ingestion_resources(
+        &self,
+    ) -> Result<InnerIngestClientResources> {
         let results = self
             .client
             .execute_command("NetDefaultDB", ".get ingestion resources", None)
             .await?;
 
-        let new_resources = results.tables.first().ok_or(anyhow::anyhow!(
-            "Kusto expected a table containing ingestion resource results, found no tables",
-        ))?;
+        let new_resources = results
+            .tables
+            .first()
+            .ok_or(IngestionResourceError::NoTablesFound)?;
 
         InnerIngestClientResources::try_from((new_resources, &self.client_options))
     }

--- a/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
+++ b/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
@@ -12,10 +12,9 @@ use azure_kusto_data::{models::TableV1, prelude::KustoClient};
 use azure_storage_blobs::prelude::ContainerClient;
 use azure_storage_queues::QueueClient;
 use serde_json::Value;
-use thiserror::Error;
 use tokio::sync::RwLock;
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum IngestionResourceError {
     #[error("{column_name} column is missing in the table")]
     ColumnNotFoundError { column_name: String },

--- a/azure-kusto-ingest/src/resource_manager/resource_uri.rs
+++ b/azure-kusto-ingest/src/resource_manager/resource_uri.rs
@@ -4,7 +4,25 @@ use azure_storage_blobs::prelude::{ClientBuilder, ContainerClient};
 use azure_storage_queues::{QueueClient, QueueServiceClientBuilder};
 use url::Url;
 
-use anyhow::Result;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ResourceUriError {
+    #[error("URI scheme must be 'https', was '{0}'")]
+    InvalidScheme(String),
+
+    #[error("Object name is missing in the URI")]
+    MissingObjectName,
+
+    #[error("SAS token is missing in the URI as a query parameter")]
+    MissingSasToken,
+
+    #[error(transparent)]
+    ParseError(#[from] url::ParseError),
+
+    #[error(transparent)]
+    AzureError(#[from] azure_core::Error),
+}
 
 /// Parsing logic of resource URIs as returned by the Kusto management endpoint
 #[derive(Debug, Clone)]
@@ -15,18 +33,14 @@ pub(crate) struct ResourceUri {
 }
 
 impl TryFrom<&str> for ResourceUri {
-    type Error = anyhow::Error;
+    type Error = ResourceUriError;
 
-    fn try_from(uri: &str) -> Result<Self> {
+    fn try_from(uri: &str) -> Result<Self, Self::Error> {
         let parsed_uri = Url::parse(uri)?;
 
         let scheme = match parsed_uri.scheme() {
             "https" => "https".to_string(),
-            other_scheme => {
-                return Err(anyhow::anyhow!(
-                    "URI scheme must be 'https', was '{other_scheme}'"
-                ))
-            }
+            other_scheme => return Err(ResourceUriError::InvalidScheme(other_scheme.to_string())),
         };
 
         let service_uri = scheme
@@ -36,17 +50,13 @@ impl TryFrom<&str> for ResourceUri {
                 .expect("Url::parse should always return a host for a URI");
 
         let object_name = match parsed_uri.path().trim_start().trim_start_matches('/') {
-            "" => return Err(anyhow::anyhow!("Object name is missing in the URI")),
+            "" => return Err(ResourceUriError::MissingObjectName),
             name => name.to_string(),
         };
 
         let sas_token = match parsed_uri.query() {
             Some(query) => query.to_string(),
-            None => {
-                return Err(anyhow::anyhow!(
-                    "SAS token is missing in the URI as a query parameter"
-                ))
-            }
+            None => return Err(ResourceUriError::MissingSasToken),
         };
         let sas_token = StorageCredentials::sas_token(sas_token)?;
 
@@ -138,6 +148,10 @@ mod tests {
         println!("{:#?}", resource_uri);
 
         assert!(resource_uri.is_err());
+        assert!(matches!(
+            resource_uri.unwrap_err(),
+            ResourceUriError::ParseError(_)
+        ));
     }
 
     #[test]
@@ -147,6 +161,10 @@ mod tests {
         println!("{:#?}", resource_uri);
 
         assert!(resource_uri.is_err());
+        assert!(matches!(
+            resource_uri.unwrap_err(),
+            ResourceUriError::MissingObjectName
+        ));
     }
 
     #[test]
@@ -156,6 +174,10 @@ mod tests {
         println!("{:#?}", resource_uri);
 
         assert!(resource_uri.is_err());
+        assert!(matches!(
+            resource_uri.unwrap_err(),
+            ResourceUriError::MissingSasToken
+        ));
     }
 
     #[test]

--- a/azure-kusto-ingest/src/resource_manager/resource_uri.rs
+++ b/azure-kusto-ingest/src/resource_manager/resource_uri.rs
@@ -4,9 +4,7 @@ use azure_storage_blobs::prelude::{ClientBuilder, ContainerClient};
 use azure_storage_queues::{QueueClient, QueueServiceClientBuilder};
 use url::Url;
 
-use thiserror::Error;
-
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ResourceUriError {
     #[error("URI scheme must be 'https', was '{0}'")]
     InvalidScheme(String),

--- a/azure-kusto-ingest/src/resource_manager/utils.rs
+++ b/azure-kusto-ingest/src/resource_manager/utils.rs
@@ -1,15 +1,10 @@
-use anyhow::Result;
 use azure_kusto_data::models::TableV1;
 
 /// Helper to get a column index from a table
-// TODO: this could be moved upstream into Kusto Data - would likely result in a change to the API of this function to return an Option<usize>
-pub fn get_column_index(table: &TableV1, column_name: &str) -> Result<usize> {
+// TODO: this could be moved upstream into Kusto Data
+pub fn get_column_index(table: &TableV1, column_name: &str) -> Option<usize> {
     table
         .columns
         .iter()
         .position(|c| c.column_name == column_name)
-        .ok_or(anyhow::anyhow!(
-            "{} column is missing in the table",
-            column_name
-        ))
 }


### PR DESCRIPTION
Removes use of `anyhow`, instead instrumenting errors for the ingestion library crate using `thiserror`.

Also includes the markup for using scopes over an explicit drop call.

See https://github.com/Azure/azure-kusto-rust/pull/29