### PR TITLE
Use async-lock rather than tokio for RwLock

### DIFF
--- a/azure-kusto-ingest/Cargo.toml
+++ b/azure-kusto-ingest/Cargo.toml
@@ -13,12 +13,15 @@ azure_storage = "0.19"
 azure_storage_blobs = "0.19"
 azure_storage_queues = "0.19"
 
+async-lock = "3"
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
 rand = "0.8"
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 url = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros"] }

--- a/azure-kusto-ingest/src/resource_manager/authorization_context.rs
+++ b/azure-kusto-ingest/src/resource_manager/authorization_context.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
+use async_lock::RwLock;
 use azure_kusto_data::prelude::KustoClient;
 use serde_json::Value;
-use tokio::sync::RwLock;
 
 use super::cache::{Cached, ThreadSafeCachedValue};
 use super::utils::get_column_index;

--- a/azure-kusto-ingest/src/resource_manager/cache.rs
+++ b/azure-kusto-ingest/src/resource_manager/cache.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::sync::RwLock;
+use async_lock::RwLock;
 
 /// Wrapper around a value that allows for storing when the value was last updated,
 /// as well as the period after which it should be refreshed (i.e. expired)

--- a/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
+++ b/azure-kusto-ingest/src/resource_manager/ingest_client_resources.rs
@@ -7,12 +7,12 @@ use super::{
     resource_uri::{ClientFromResourceUri, ResourceUri},
     utils, RESOURCE_REFRESH_PERIOD,
 };
+use async_lock::RwLock;
 use azure_core::ClientOptions;
 use azure_kusto_data::{models::TableV1, prelude::KustoClient};
 use azure_storage_blobs::prelude::ContainerClient;
 use azure_storage_queues::QueueClient;
 use serde_json::Value;
-use tokio::sync::RwLock;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IngestionResourceError {


### PR DESCRIPTION
As requested in https://github.com/Azure/azure-kusto-rust/pull/29#discussion_r1407529311

This is the RwLock that the main Azure SDK for Rust uses.
- [Usage in `azure_identity`](https://github.com/Azure/azure-sdk-for-rust/blob/a3a681cbb4556f95a292065d4bb17381cbea8b79/sdk/identity/src/token_credentials/cache.rs)
- [Usage in `azure_storage`](https://github.com/Azure/azure-sdk-for-rust/blob/a3a681cbb4556f95a292065d4bb17381cbea8b79/sdk/storage/src/authorization/mod.rs)